### PR TITLE
Added Strixx to custom google search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,7 @@ I do not accept any donations or add a sponsorship button for this repository. I
 
 ### Custom "Google" Search Engines
 - [FileChef](https://anonym.to/?http://filechef.com/) - (`insecure`) - Get direct download links for almost anything!
+- [Strixx](https://maximousblk.github.io/strixx) - An open directory search tool. 
 - [Jimmyr](https://anonym.to/?http://www.jimmyr.com/mp3_search.php) - (`insecure`) - Yet abother Music search engine.
 - [lumpySoft.com](https://anonym.to/?https://lumpysoft.com/) - A Google index search with predefined tags.
 - [mattpalm.com/search](https://anonym.to/?https://mattpalm.com/search/) - Get direct download links for almost anything.


### PR DESCRIPTION
Strixx is a tool I made as an answer to filechef being made using jQuery and bootstrap. I thought better can be done using everything as vanilla as possible.

It is a PWA, has Dark mode, clean UI, more options, basically a successor to filechef.

Keep in mind though that the UI is heavily under development but it will work effortlessly nevertheless. 